### PR TITLE
Fix Groundwaterstation icon.

### DIFF
--- a/src/_icons.scss
+++ b/src/_icons.scss
@@ -64,7 +64,6 @@
 .#{$lz-css-prefix}-default:before {
 	content: $lz-var-default;
 }
-.#{$lz-css-prefix}-groundwaterstation:before,
 .#{$lz-css-prefix}-database:before {
 	content: $lz-var-database;
 }
@@ -97,6 +96,7 @@
 	content: $lz-var-surface-water;
 }
 
+.#{$lz-css-prefix}-groundwaterstation:before,
 .#{$lz-css-prefix}-monitoring-well:before {
 	content: $lz-var-monitoring-well;
 }


### PR DESCRIPTION
Was database icon, should be drop on its side.

Will update docs when this PR is merged.

Fixes https://github.com/nens/lizard-nxt/issues/1681.
